### PR TITLE
Fix panic in case server replies with invalid format

### DIFF
--- a/hibp.go
+++ b/hibp.go
@@ -122,7 +122,7 @@ func (c *Client) Compromised(value string) (bool, error) {
 	}
 
 	for _, target := range response {
-		if target[:35] == suffix {
+		if len(target) >= 37 && target[:35] == suffix {
 			if _, err = strconv.ParseInt(target[36:], 10, 64); err != nil {
 				return false, err
 			}


### PR DESCRIPTION
We recently experienced panics caused by reply from the server that did not conform to the expected format. I don't have the exact content that created the crash, but this will prevent it.

```
panic: runtime error: slice bounds out of range [:35] with length 0 
```