### PR TITLE
If have i been pwned's response is shorter than expected, ignore it

### DIFF
--- a/hibp.go
+++ b/hibp.go
@@ -122,6 +122,9 @@ func (c *Client) Compromised(value string) (bool, error) {
 	}
 
 	for _, target := range response {
+		if len(target) < 36 {
+			continue
+		}
 		if target[:35] == suffix {
 			if _, err = strconv.ParseInt(target[36:], 10, 64); err != nil {
 				return false, err


### PR DESCRIPTION
This avoids panicking when hibp responds with extra newlines