### PR TITLE
Add count of compromises

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
-test:
+build:
 	docker build -t test-pwned-passwords -f test.Dockerfile .
+
+test:
 	docker run --volume=$(CURDIR):/go/pwned-passwords/ test-pwned-passwords go test

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,3 @@
+test:
+	docker build -t test-pwned-passwords -f test.Dockerfile .
+	docker run --volume=$(CURDIR):/go/pwned-passwords/ test-pwned-passwords go test

--- a/hibp.go
+++ b/hibp.go
@@ -102,7 +102,13 @@ func (c *Client) Do(req *http.Request) ([]string, error) {
 }
 
 // Compromised will build and execute a request to HIBP to check to see if the passed value is compromised or not.
-func (c *Client) Compromised(value string) (bool, int64, error) {
+func (c *Client) Compromised(value string) (bool, error) {
+	compromised, _, error := c.CompromisedCount(value)
+	return compromised, error
+}
+
+// Compromised will build and execute a request to HIBP to check to see if the passed value is compromised or not.
+func (c *Client) CompromisedCount(value string) (bool, int64, error) {
 	if value == "" {
 		return false, 0, errors.New("value for compromised check cannot be empty")
 	}

--- a/hibp.go
+++ b/hibp.go
@@ -102,9 +102,9 @@ func (c *Client) Do(req *http.Request) ([]string, error) {
 }
 
 // Compromised will build and execute a request to HIBP to check to see if the passed value is compromised or not.
-func (c *Client) Compromised(value string) (bool, error) {
+func (c *Client) Compromised(value string) (bool, int64, error) {
 	if value == "" {
-		return false, errors.New("value for compromised check cannot be empty")
+		return false, 0, errors.New("value for compromised check cannot be empty")
 	}
 
 	hashedStr := hashString(value)
@@ -113,12 +113,12 @@ func (c *Client) Compromised(value string) (bool, error) {
 
 	request, err := c.NewRequest("GET", fmt.Sprintf("range/%s", prefix), nil)
 	if err != nil {
-		return false, err
+		return false, 0, err
 	}
 
 	response, err := c.Do(request)
 	if err != nil {
-		return false, err
+		return false, 0, err
 	}
 
 	for _, target := range response {
@@ -127,15 +127,16 @@ func (c *Client) Compromised(value string) (bool, error) {
 		}
 
 		if target[:35] == suffix {
-			if _, err = strconv.ParseInt(target[36:], 10, 64); err != nil {
-				return false, err
+			var count int64
+			if count, err = strconv.ParseInt(target[36:], 10, 64); err != nil {
+				return false, 0, err
 			}
 
-			return true, err
+			return true, count, err
 		}
 	}
 
-	return false, err
+	return false, 0, err
 }
 
 // hashString will return a sha1 hash of the given value.

--- a/hibp_test.go
+++ b/hibp_test.go
@@ -19,17 +19,13 @@ func TestClientCustomHTTPClient(t *testing.T) {
 		Timeout: 3 * time.Second,
 	})
 
-	compromised, count, err := client.Compromised("p@ssword")
+	compromised, err := client.Compromised("p@ssword")
 	if err != nil {
 		t.Fatalf("Unexpected error running client.Pwned.Compromised(): %s", err)
 	}
 
 	if !compromised {
 		t.Fatalf("Expected compromised hash (p@ssword) to be true but got: %v", compromised)
-	}
-
-	if count == 0 {
-		t.Fatalf("Expected compromised hash (p@ssword) to have been compromised at least once but got: %v", count)
 	}
 }
 
@@ -40,7 +36,24 @@ func TestCompromisedHash(t *testing.T) {
 
 	client := NewClient()
 
-	compromised, count, err := client.Compromised("p@ssword")
+	compromised, err := client.Compromised("p@ssword")
+	if err != nil {
+		t.Fatalf("Unexpected error running client.Pwned.Compromised(): %s", err)
+	}
+
+	if !compromised {
+		t.Fatalf("Expected compromised hash (p@ssword) to be true but got: %v", compromised)
+	}
+}
+
+// TestCompromisedCountHash will test a compromised value against the HIBP API.
+func TestCompromisedCountHash(t *testing.T) {
+	// Register the test.
+	RegisterTestingT(t)
+
+	client := NewClient()
+
+	compromised, count, err := client.CompromisedCount("p@ssword")
 	if err != nil {
 		t.Fatalf("Unexpected error running client.Pwned.Compromised(): %s", err)
 	}
@@ -64,7 +77,27 @@ func TestNonCompromisedHash(t *testing.T) {
 	// Check if input is compromised.
 	value := fmt.Sprintf("SHOULD_NOT_BE_COMPROMISED_%s", time.Now().Format("2006-01-02 15:04:05"))
 
-	compromised, count, err := client.Compromised(value)
+	compromised, err := client.Compromised(value)
+	if err != nil {
+		t.Fatalf("Unexpected error running client.Pwned.Compromised(): %s", err)
+	}
+
+	if compromised {
+		t.Fatalf("Expected non-compromised hash to be false but got: %v", compromised)
+	}
+}
+
+// TestNonCompromisedCountHash will test a non-compromised value against the HIBP API.
+func TestNonCompromisedCountHash(t *testing.T) {
+	// Register the test.
+	RegisterTestingT(t)
+
+	client := NewClient()
+
+	// Check if input is compromised.
+	value := fmt.Sprintf("SHOULD_NOT_BE_COMPROMISED_%s", time.Now().Format("2006-01-02 15:04:05"))
+
+	compromised, count, err := client.CompromisedCount(value)
 	if err != nil {
 		t.Fatalf("Unexpected error running client.Pwned.Compromised(): %s", err)
 	}
@@ -85,7 +118,28 @@ func TestEmptyCompromisedHash(t *testing.T) {
 	client := NewClient()
 
 	// Check if input is compromised.
-	compromised, count, err := client.Compromised("")
+	compromised, err := client.Compromised("")
+	if err == nil {
+		t.Fatal("Expected error when checking empty value, but got: nil")
+	}
+
+	if err.Error() != "value for compromised check cannot be empty" {
+		t.Fatalf("Expected err to read 'value for compromised check cannot be empty' but got: '%v'", err)
+	}
+
+	if compromised {
+		t.Fatalf("Expected empty compromised hash to be false but got: %v", compromised)
+	}
+}
+
+func TestEmptyCompromisedCountHash(t *testing.T) {
+	// Register the test.
+	RegisterTestingT(t)
+
+	client := NewClient()
+
+	// Check if input is compromised.
+	compromised, count, err := client.CompromisedCount("")
 	if err == nil {
 		t.Fatal("Expected error when checking empty value, but got: nil")
 	}

--- a/hibp_test.go
+++ b/hibp_test.go
@@ -19,13 +19,17 @@ func TestClientCustomHTTPClient(t *testing.T) {
 		Timeout: 3 * time.Second,
 	})
 
-	compromised, err := client.Compromised("p@ssword")
+	compromised, count, err := client.Compromised("p@ssword")
 	if err != nil {
 		t.Fatalf("Unexpected error running client.Pwned.Compromised(): %s", err)
 	}
 
 	if !compromised {
 		t.Fatalf("Expected compromised hash (p@ssword) to be true but got: %v", compromised)
+	}
+
+	if count == 0 {
+		t.Fatalf("Expected compromised hash (p@ssword) to have been compromised at least once but got: %v", count)
 	}
 }
 
@@ -36,13 +40,17 @@ func TestCompromisedHash(t *testing.T) {
 
 	client := NewClient()
 
-	compromised, err := client.Compromised("p@ssword")
+	compromised, count, err := client.Compromised("p@ssword")
 	if err != nil {
 		t.Fatalf("Unexpected error running client.Pwned.Compromised(): %s", err)
 	}
 
 	if !compromised {
 		t.Fatalf("Expected compromised hash (p@ssword) to be true but got: %v", compromised)
+	}
+
+	if count == 0 {
+		t.Fatalf("Expected compromised hash (p@ssword) to have been compromised at least once but got: %v", count)
 	}
 }
 
@@ -56,13 +64,17 @@ func TestNonCompromisedHash(t *testing.T) {
 	// Check if input is compromised.
 	value := fmt.Sprintf("SHOULD_NOT_BE_COMPROMISED_%s", time.Now().Format("2006-01-02 15:04:05"))
 
-	compromised, err := client.Compromised(value)
+	compromised, count, err := client.Compromised(value)
 	if err != nil {
 		t.Fatalf("Unexpected error running client.Pwned.Compromised(): %s", err)
 	}
 
 	if compromised {
 		t.Fatalf("Expected non-compromised hash to be false but got: %v", compromised)
+	}
+
+	if count != 0 {
+		t.Fatalf("Expected non-compromised hash to have been compromised exactly 0 times but got: %v", count)
 	}
 }
 
@@ -73,7 +85,7 @@ func TestEmptyCompromisedHash(t *testing.T) {
 	client := NewClient()
 
 	// Check if input is compromised.
-	compromised, err := client.Compromised("")
+	compromised, count, err := client.Compromised("")
 	if err == nil {
 		t.Fatal("Expected error when checking empty value, but got: nil")
 	}
@@ -84,5 +96,9 @@ func TestEmptyCompromisedHash(t *testing.T) {
 
 	if compromised {
 		t.Fatalf("Expected empty compromised hash to be false but got: %v", compromised)
+	}
+
+	if count != 0 {
+		t.Fatalf("Expected empty compromised hash to have been compromised exactly 0 times but got: %v", count)
 	}
 }

--- a/test.Dockerfile
+++ b/test.Dockerfile
@@ -2,6 +2,6 @@ FROM golang:1.13-buster
 
 COPY go.* ./pwned-passwords/
 
-WORKDIR ./pwned-passwords/
+WORKDIR /go/pwned-passwords/
 
 RUN go mod download

--- a/test.Dockerfile
+++ b/test.Dockerfile
@@ -1,0 +1,7 @@
+FROM golang:1.13-buster
+
+COPY go.* ./pwned-passwords/
+
+WORKDIR ./pwned-passwords/
+
+RUN go mod download


### PR DESCRIPTION
This MR would resolve https://github.com/mattevans/pwned-passwords/issues/4 by adding a new method `func (c *Client) CompromisedCount(value string) (bool, int64, error)`.
I turned `func (c *Client) Compromised(value string) (bool, error) ` into a wrapper that simply doesn't return the `int` count. This maintains the API contract while minimizing extra lines of code.

I also containerized testing by adding a `Makefile` and `Dockerfile`, but those have no effect on functionality. I've been running `make test` repeatedly to validate changes; `make build` once to build the base image.